### PR TITLE
Generalize timestamp column name in `align_move()`

### DIFF
--- a/R/align_move.R
+++ b/R/align_move.R
@@ -178,7 +178,7 @@ align_move <- function(m, res = "minimum", start_end_time = NULL, fill_na_values
   m_aligned <- mt_set_track_data(m_aligned, mt_track_data(m))
   
   # reorder by time
-  m_aligned <- m_aligned[order(m_aligned$timestamp),]
+  m_aligned <- m_aligned[order(mt_time(m_aligned)),]
   m_aligned <- m_aligned[order(mt_track_id(m_aligned)),]
   
   # fill variables


### PR DESCRIPTION
Fixes #138; prevents error if input data store temporal information in a column not named `"timestamp"`