### PR TITLE
Close graphics device between frames

### DIFF
--- a/R/animate_frames.R
+++ b/R/animate_frames.R
@@ -110,13 +110,20 @@ animate_frames <- function(frames, out_file, fps = 25, width = 700, height = 700
   dir.create(frames_dir, recursive = T)
   
   tryCatch({
-    file <- file.path(frames_dir, "frame_%05d.png")
-    grDevices::png(file, width = width, height = height, res = res)
-    graphics::par(ask = FALSE)
-    .lapply(1:length(frames), function(i){
-      quiet(print(frames[[i]]))
-    }, moveVis.n_cores = 1)
-    grDevices::dev.off()
+    .lapply(
+      1:length(frames), 
+      function(i) {
+        file <- file.path(frames_dir, sprintf("frame_%05d.png", i))
+        
+        grDevices::png(file, width = width, height = height, res = res)
+        graphics::par(ask = FALSE)
+        
+        quiet(print(frames[[i]]))
+        grDevices::dev.off()
+      }, 
+      moveVis.n_cores = 1
+    )
+    
     frames_files <- list.files(frames_dir, full.names = TRUE)
     
     # animate PNGs

--- a/tests/testthat/test-animate_frames.R
+++ b/tests/testthat/test-animate_frames.R
@@ -6,9 +6,11 @@ test_that("animate_frames", {
   frames <- frames_spatial(m.aligned, r_grad, r_type = "gradient", verbose = F)[1:10]
   file.gif <- tempfile(tmpdir = test_dir, fileext = ".gif")
   expect_null(animate_frames(frames, out_file = file.gif, verbose = F, overwrite = T, display = F))
+  expect_true(file.exists(file.gif))
   
   file.mov <- tempfile(tmpdir = test_dir, fileext = ".mov")
   expect_null(animate_frames(frames, out_file = file.mov, verbose = F, overwrite = T, display = F))
+  expect_true(file.exists(file.mov))
   
   # end pause
   expect_null(animate_frames(frames, out_file = file.mov, verbose = F, overwrite = T, display = F, end_pause = 2))


### PR DESCRIPTION
Resolves #145. Proposing a small tweak to prevent accumulated memory use when large animations are rendered by closing the graphics device between frame renderings rather than after all frames have been rendered.